### PR TITLE
Fix fetcher default params & clean exports

### DIFF
--- a/src/dataprep/features/__init__.py
+++ b/src/dataprep/features/__init__.py
@@ -1,23 +1,43 @@
 from src.dataprep.features.price_features import (
-    compute_6m_return, 
-    compute_12m_return, 
+    compute_6m_return,
+    compute_12m_return,
     compute_sector_relative_return,
     compute_payout_ratio,
     compute_volatility,
-    compute_max_drawdown
+    compute_max_drawdown,
 )
 from src.dataprep.features.metadata_features import encode_sector
 from src.dataprep.features.utils import ensure_date_column, find_nearest_price, adjust_series_for_splits
 from src.dataprep.features.dividend_features import (
     compute_dividend_cagr,
-    compute_yield_vs_median
+    compute_yield_vs_median,
 )
 from src.dataprep.features.growth_features import (
     compute_eps_cagr,
-    compute_fcf_cagr
+    compute_fcf_cagr,
 )
 from src.dataprep.features.fundamental_features import (
     compute_net_debt_to_ebitda,
-    compute_ebit_interest_cover
+    compute_ebit_interest_cover,
 )
 from src.dataprep.features.valuation_features import extract_latest_pe_pfcf
+
+__all__ = [
+    "compute_6m_return",
+    "compute_12m_return",
+    "compute_sector_relative_return",
+    "compute_payout_ratio",
+    "compute_volatility",
+    "compute_max_drawdown",
+    "encode_sector",
+    "ensure_date_column",
+    "find_nearest_price",
+    "adjust_series_for_splits",
+    "compute_dividend_cagr",
+    "compute_yield_vs_median",
+    "compute_eps_cagr",
+    "compute_fcf_cagr",
+    "compute_net_debt_to_ebitda",
+    "compute_ebit_interest_cover",
+    "extract_latest_pe_pfcf",
+]

--- a/src/dataprep/fetcher/base.py
+++ b/src/dataprep/fetcher/base.py
@@ -10,7 +10,9 @@ class FMPClient:
         self.api_key = os.getenv("FMP_API_KEY")
         self.base_url = "https://financialmodelingprep.com/api/v3"
 
-    def fetch(self, endpoint: str, params: dict = {}) -> dict:
+    def fetch(self, endpoint: str, params: dict | None = None) -> dict:
+        if params is None:
+            params = {}
         url = f"{self.base_url}/{endpoint}"
         headers = {"User-Agent": "Mozilla/5.0"}
         params["apikey"] = self.api_key


### PR DESCRIPTION
## Summary
- avoid mutable default arg in `FMPClient.fetch`
- rewrite `src/dataprep/features/__init__.py` to remove stray text and expose public API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_683fe12413588329a65c687e5c833941